### PR TITLE
Properly set established time unit

### DIFF
--- a/juniper-bgp.yaml
+++ b/juniper-bgp.yaml
@@ -143,7 +143,7 @@ zabbix_export:
               snmp_oid: '.1.3.6.1.4.1.2636.5.1.1.2.4.1.1.1.{#SNMPINDEX}'
               key: 'net.bgp.peer.uptime[{#BGPEERREMOTEAS}, {#BGPPEERREMOTEADDRESS}]'
               delay: 5m
-              units: seconds
+              units: s
               applications:
                 -
                   name: BGP


### PR DESCRIPTION
This simple PR just fixes the Established time item unit to properly use the `s` unit, giving the automatically translated time, i.e. `4m 8d 23h` instead of `Mseconds`.